### PR TITLE
Custom sources taxonomy patch

### DIFF
--- a/bdqc_taxa/bryoquel.py
+++ b/bdqc_taxa/bryoquel.py
@@ -53,7 +53,7 @@ def match_taxa(species) -> dict:
     c.execute('''
     SELECT bryoquel.* FROM bryoquel
     JOIN bryoquel_fts ON bryoquel_fts.scientific_name = bryoquel.scientific_name
-    WHERE bryoquel_fts LIKE ?
+    WHERE bryoquel_fts.scientific_name MATCH ?
     ORDER BY rank
     LIMIT 1
     ''', (f'"{species}"',))

--- a/bdqc_taxa/cdpnq.py
+++ b/bdqc_taxa/cdpnq.py
@@ -54,7 +54,7 @@ def match_taxa_odonates(name) -> dict:
     c.execute('''
     SELECT cdpnq_odonates.* FROM cdpnq_odonates
     JOIN cdpnq_odonates_fts ON cdpnq_odonates_fts.name = cdpnq_odonates.name
-    WHERE cdpnq_odonates_fts LIKE ?
+    WHERE cdpnq_odonates_fts.name MATCH ?
     ORDER BY rank
     ''', (f'"{name}"',))
 
@@ -109,7 +109,7 @@ def match_taxa_vertebrates(name) -> dict:
     c.execute('''
     SELECT cdpnq_vertebrates.* FROM cdpnq_vertebrates
     JOIN cdpnq_vertebrates_fts ON cdpnq_vertebrates_fts.name = cdpnq_vertebrates.name
-    WHERE cdpnq_vertebrates_fts LIKE ?
+    WHERE cdpnq_vertebrates_fts.name MATCH ?
     ORDER BY rank
     ''', (f'"{name}"',))
 

--- a/tests/test_bryoquel.py
+++ b/tests/test_bryoquel.py
@@ -16,17 +16,6 @@ class TestBryoquel(TestCase):
         self.assertEqual(result['clade'], 'Musci')
         self.assertEqual(result['authorship'], '(Hedw.) Schwägr.')
 
-    def test_match_species_canonical(self, species='Aulacomnium palustre (Hedw.) Schwägr.'):
-        # Test a species that is in the database
-        result = match_taxa(species)
-        self.assertEqual(result['id'], "ID269")
-        self.assertEqual(result['family'], 'Aulacomniaceae')
-        self.assertEqual(result['scientific_name'], 'Aulacomnium palustre')
-        self.assertEqual(result['vernacular_name_fr'], 'aulacomnie des marais')
-        self.assertEqual(result['vernacular_name_en'], 'ribbed bog moss')
-        self.assertEqual(result['clade'], 'Musci')
-        self.assertEqual(result['authorship'], '(Hedw.) Schwägr.')
-
     def test_match_family(self, family='Aulacomniaceae'):
         # Test a species that is in the database
         result = match_taxa(family)

--- a/tests/test_cdpnq.py
+++ b/tests/test_cdpnq.py
@@ -24,11 +24,6 @@ class TestCdpnqOdonates(unittest.TestCase):
         self.assertEqual(result['name'], 'Libellula')
         self.assertEqual(result['rank'], 'genus')
 
-    def test_match_canonical(self, name = 'Libellula luctuosa Burmeister, 1839'):
-        result = cdpnq.match_taxa_odonates(name)
-        self.assertEqual(result['name'], 'Libellula luctuosa')
-        self.assertEqual(result['rank'], 'species')
-
 class TestCdpnqVertebrates(unittest.TestCase):
     def test_match_species(self, name = 'Pica hudsonia'):
         result = cdpnq.match_taxa_vertebrates(name)

--- a/tests/test_taxa_ref.py
+++ b/tests/test_taxa_ref.py
@@ -259,13 +259,6 @@ class TestTaxaRef(unittest.TestCase):
         # Assert there is a genus
         self.assertTrue(any([ref.rank == 'genus' for ref in refs]))
 
-    def test_from_bryoquel_canonical(self, name='Anthelia julacea (L.) Dumort.'):
-        refs = taxa_ref.TaxaRef.from_bryoquel(name)
-        self.assertTrue(len(refs) >= 1)
-        self.assertTrue(all([ref.source_id == 1001 for ref in refs]))
-        # Assert there is a family
-        self.assertTrue(any([ref.rank == 'family' for ref in refs]))
-
         # Assert there is a genus
         self.assertTrue(any([ref.rank == 'genus' for ref in refs]))
 


### PR DESCRIPTION
- Reintroduce MATCH operator in custum sources name matching
- Remove full canonical name matching as it is not needed anymore
- Pass all tests