### PR TITLE
🐛 remove all forms of fuzzy matching in custom sources vernacular queries

### DIFF
--- a/bdqc_taxa/__about__.py
+++ b/bdqc_taxa/__about__.py
@@ -16,11 +16,11 @@ __uri__ = "https://github.com/ReseauBiodiversiteQuebec/bdqc-taxa"
 _version = OrderedDict(
     major = 0,
     minor = 15,
-    patch = 0
+    patch = 1
 )
 __version__ = ".".join([str(v) for v in _version.values()])
 
 __author__ = "Vincent Beauregard"
 __email__ = "vincent.beauregard@usherbrooke.ca"
 
-__copyright__ = "2021-2023 %s" % __author__
+__copyright__ = "2021-2024 %s" % __author__

--- a/bdqc_taxa/bryoquel.py
+++ b/bdqc_taxa/bryoquel.py
@@ -78,3 +78,61 @@ def match_taxa(species) -> dict:
     # If there is no match, return None
     else:
         return None
+    
+
+def match_taxa_exact(species) -> dict:
+    """Match *exactly* a species name to the Bryoquel database
+    
+    Parameters
+    ----------
+    species : str
+        The species name to match
+    
+    Returns
+    -------
+    dict
+        A dictionary with the following keys:
+        - id: the Bryoquel IDtaxon
+        - scientific_name: Noms latins accept�s du taxon, sans auteur
+        - taxon_rank: Taxon rank
+        - genus: Taxon genus
+        - family: Taxon family
+        - clade: Taxon clade
+        - canonical_full: Noms latins accept�s du taxon, avec auteur
+        - authorship: Auteur obtenu de Noms latins accept�s
+        - vernacular_name_fr: Noms fran�ais accept�s
+        - vernacular_name_en: Noms anglais accept�s
+    """
+    # Get the cursor
+    c = conn.cursor()
+    
+    # Get the species name
+    species = species.strip()
+
+    c.execute('''
+    SELECT * FROM bryoquel
+    WHERE scientific_name = ?
+    ORDER BY taxon_rank
+    LIMIT 1
+    ''', (species,))
+
+    rows = c.fetchone()
+
+    # If there is a match, return the result
+    if rows:
+        return {
+            'db_id': rows[0],
+            'id': rows[1],
+            'scientific_name': rows[2],
+            'taxon_rank': rows[3],
+            'genus': rows[4],
+            'family': rows[5],
+            'clade': rows[6],
+            'canonical_full': rows[7],
+            'authorship': rows[8],
+            'vernacular_name_fr': rows[9],
+            'vernacular_name_en': rows[10]
+        }
+    # If there is no match, return None
+    else:
+        return None

--- a/bdqc_taxa/cdpnq.py
+++ b/bdqc_taxa/cdpnq.py
@@ -78,6 +78,61 @@ def match_taxa_odonates(name) -> dict:
         }
     else:
         return None
+    
+def match_taxa_odonates_exact(name) -> dict:
+    """Match *exactly* a species name to the Bryoquel database
+    Parameters
+    ----------
+    name : str
+
+    Returns
+    -------
+    dict
+        A dictionary with the following keys:
+        name: scientific name
+        valid_name: valid scientific name
+        rank: rank of the taxa
+        synonym: boolean indicating if the name is a synonym
+        author: author of the scientific name
+        canonical_full: canonical full name
+        vernacular_fr: vernacular name in French
+        vernacular_fr2: vernacular name in French from Natureserve
+
+    """
+
+    # Get the cursor
+    c = conn.cursor()
+
+    # Get the species name
+    name = name.strip()
+
+    c.execute('''
+    SELECT * FROM cdpnq_odonates
+    WHERE name = ?
+    OR valid_name = ?
+    ORDER BY rank
+    ''', (name, name))
+
+    # Get the first result
+    result = c.fetchone()
+
+    # Close the cursor
+    c.close()
+
+    # Return the result
+    if result:
+        return {
+            'name': result[0],
+            'valid_name': result[1],
+            'rank': result[2],
+            'synonym': result[3],
+            'author': result[4],
+            'canonical_full': result[5],
+            'vernacular_fr': result[6],
+            'vernacular_fr2': result[7]
+        }
+    else:
+        return None
 
 def match_taxa_vertebrates(name) -> dict:
     """Match a species name to the CDPQN database
@@ -134,6 +189,60 @@ def match_taxa_vertebrates(name) -> dict:
     else:
         return None
 
+def match_taxa_vertebrates_exact(name) -> dict:
+    """Match *exactly* a species name to the CDPQN database
+    Parameters
+    ----------
+    name : str
+
+    Returns
+    -------
+    dict
+        A dictionary with the following keys:
+        name: scientific name
+        valid_name: valid scientific name
+        rank: rank of the taxa
+        synonym: boolean indicating if the name is a synonym
+        author: author of the scientific name
+        canonical_full: canonical full name
+        vernacular_fr: vernacular name in French
+        vernacular_en: vernacular name in English
+    """
+
+    # Get the cursor
+    c = conn.cursor()
+
+    # Get the species name
+    name = name.strip()
+
+    c.execute('''
+    SELECT * FROM cdpnq_vertebrates
+    WHERE name = ?
+    OR valid_name = ?
+    ORDER BY rank
+    ''', (name, name))
+
+    # Get the first result
+    result = c.fetchone()
+
+    # Close the cursor
+    c.close()
+
+    # Return the result
+    if result:
+        return {
+            'name': result[0],
+            'valid_name': result[1],
+            'rank': result[2],
+            'synonym': result[3],
+            'author': result[4],
+            'canonical_full': result[5],
+            'vernacular_fr': result[6],
+            'vernacular_en': result[7]
+        }
+    else:
+        return None
+
 def match_taxa(name) -> dict:
     """Match a species name to the CDPNQ database
     Parameters
@@ -164,6 +273,46 @@ def match_taxa(name) -> dict:
         out = [*out, odonates]
     
     vertebrates = match_taxa_vertebrates(name)
+    if vertebrates:
+        # Add vernacular_fr2
+        vertebrates = {**vertebrates, 'vernacular_fr2': None}
+        out = [*out, vertebrates]
+    
+    if out:
+        return out
+    else:
+        return None
+    
+def match_taxa_exact(name) -> dict:
+    """Match *exactly* a species name to the CDPNQ database
+    Parameters
+    ----------
+    name : str
+
+    Returns
+    -------
+    dict
+        A dictionary with the following keys
+        name: scientific name
+        valid_name: valid scientific name
+        rank: rank of the taxa
+        synonym: boolean indicating if the name is a synonym
+        author: author of the scientific name
+        canonical_full: canonical full name
+        vernacular_fr: vernacular name in French
+        vernacular_fr2: vernacular name in French from Natureserve
+        vernacular_en: vernacular name in English
+    """
+
+    out = []
+
+    odonates = match_taxa_odonates_exact(name)
+    if odonates:
+        # Add vernacular_en
+        odonates = {**odonates, 'vernacular_en': None}
+        out = [*out, odonates]
+    
+    vertebrates = match_taxa_vertebrates_exact(name)
     if vertebrates:
         # Add vernacular_fr2
         vertebrates = {**vertebrates, 'vernacular_fr2': None}

--- a/bdqc_taxa/eliso.py
+++ b/bdqc_taxa/eliso.py
@@ -57,11 +57,10 @@ def match_taxa(name) -> dict:
     name = name.strip()
     
     c.execute('''
-    SELECT eliso_invertebrates.* FROM eliso_invertebrates
-    JOIN eliso_invertebrates_fts ON eliso_invertebrates_fts.taxa_name = eliso_invertebrates.taxa_name
-    WHERE eliso_invertebrates_fts.taxa_name MATCH ?
+    SELECT * FROM eliso_invertebrates
+    WHERE taxa_name = ?
     ORDER BY taxa_rank
-    ''', (f'"{name}"',))
+    ''', (name,))
 
     # Get the first result
     result = c.fetchone()

--- a/bdqc_taxa/vernacular.py
+++ b/bdqc_taxa/vernacular.py
@@ -84,7 +84,7 @@ class Vernacular:
 
     @classmethod
     def from_bryoquel_match(cls, name: str = ''):
-        taxa = bryoquel.match_taxa(name)
+        taxa = bryoquel.match_taxa_exact(name)
         out = []
         if taxa and taxa['vernacular_name_fr']:
             out = [*out, cls(
@@ -108,7 +108,7 @@ class Vernacular:
 
     @classmethod
     def from_cdpnq_match(cls, name: str = ''):
-        taxas = cdpnq.match_taxa(name)
+        taxas = cdpnq.match_taxa_exact(name)
         if not taxas:
             return []
         out = []

--- a/tests/test_bryoquel.py
+++ b/tests/test_bryoquel.py
@@ -2,6 +2,7 @@
 
 from unittest import TestCase
 from bdqc_taxa.bryoquel import match_taxa
+from bdqc_taxa.bryoquel import match_taxa_exact
 
 class TestBryoquel(TestCase):
     def test_match_species(self, species='Aulacomnium palustre'):
@@ -30,5 +31,35 @@ class TestBryoquel(TestCase):
     def test_match_species_bug(self, species='Ptilium crista-castrensis'):
         # Test a species that is in the database
         result = match_taxa(species)
+        # Assert any result
+        self.assertTrue(result)
+
+class TestBryoquelExact(TestCase):
+    def test_match_species(self, species='Aulacomnium palustre'):
+        # Test a species that is in the database
+        result = match_taxa_exact(species)
+        self.assertEqual(result['id'], "ID269")
+        self.assertEqual(result['family'], 'Aulacomniaceae')
+        self.assertEqual(result['scientific_name'], 'Aulacomnium palustre')
+        self.assertEqual(result['canonical_full'], 'Aulacomnium palustre (Hedw.) Schwägr.')
+        self.assertEqual(result['vernacular_name_fr'], 'aulacomnie des marais')
+        self.assertEqual(result['vernacular_name_en'], 'ribbed bog moss')
+        self.assertEqual(result['clade'], 'Musci')
+        self.assertEqual(result['authorship'], '(Hedw.) Schwägr.')
+
+    def test_match_family(self, family='Aulacomniaceae'):
+        # Test a species that is in the database
+        result = match_taxa_exact(family)
+        self.assertEqual(result['family'], 'Aulacomniaceae')
+        self.assertEqual(result['scientific_name'], 'Aulacomniaceae')
+        self.assertEqual(result['vernacular_name_fr'], None)
+        self.assertEqual(result['vernacular_name_en'], None)
+        self.assertEqual(result['clade'], 'Musci')
+        self.assertEqual(result['authorship'], None)
+
+    # Test bug case "Ptilium crista-castrensis"
+    def test_match_species_bug(self, species='Ptilium crista-castrensis'):
+        # Test a species that is in the database
+        result = match_taxa_exact(species)
         # Assert any result
         self.assertTrue(result)

--- a/tests/test_cdpnq.py
+++ b/tests/test_cdpnq.py
@@ -62,3 +62,63 @@ class TestCdpnq(unittest.TestCase):
         result = cdpnq.match_taxa(name)
         self.assertEqual(result[0]['name'], name)
         self.assertEqual(result[0]['rank'], 'species')
+
+
+class TestCdpnqOdonatesExact(unittest.TestCase):
+    def test_match_species(self, name = 'Libellula luctuosa'):
+        result = cdpnq.match_taxa_odonates_exact(name)
+        self.assertEqual(result['name'], name)
+        self.assertEqual(result['rank'], 'species')
+        
+    def test_no_match(self, name = 'Vincent Beauregard'):
+        result = cdpnq.match_taxa_odonates_exact(name)
+        self.assertEqual(result, None)
+
+    def test_match_synonym(self, name = 'Gomphus borealis'):
+        result = cdpnq.match_taxa_odonates_exact(name)
+        self.assertEqual(result['valid_name'], 'Phanogomphus borealis')
+        self.assertEqual(result['rank'], 'species')
+
+    def test_match_genus(self, name = 'Libellula'):
+        result = cdpnq.match_taxa_odonates_exact(name)
+        self.assertEqual(result['name'], 'Libellula')
+        self.assertEqual(result['rank'], 'genus')
+
+class TestCdpnqVertebratesExact(unittest.TestCase):
+    def test_match_species(self, name = 'Pica hudsonia'):
+        result = cdpnq.match_taxa_vertebrates(name)
+        self.assertEqual(result['name'], name)
+        self.assertEqual(result['rank'], 'species')
+
+    def test_no_match(self, name = 'Vincent Beauregard'):
+        result = cdpnq.match_taxa_vertebrates_exact(name)
+        self.assertEqual(result, None)
+
+    def test_match_synonym(self, name = 'Pica pica'):
+        result = cdpnq.match_taxa_vertebrates_exact(name)
+        self.assertEqual(result['valid_name'], 'Pica hudsonia')
+        self.assertEqual(result['rank'], 'species')
+
+    def test_match_genus(self, name = 'Pica'):
+        result = cdpnq.match_taxa_vertebrates_exact(name)
+        self.assertEqual(result['name'], 'Pica')
+        self.assertEqual(result['rank'], 'genus')
+
+    
+
+
+# Test match_taxa for both odonates and vertebrates
+class TestCdpnqExact(unittest.TestCase):
+    def test_match_species(self, name = 'Libellula luctuosa'):
+        result = cdpnq.match_taxa_exact(name)
+        self.assertEqual(result[0]['name'], name)
+        self.assertEqual(result[0]['rank'], 'species')
+
+    def test_no_match(self, name = 'Vincent Beauregard'):
+        result = cdpnq.match_taxa_exact(name)
+        self.assertFalse(result)
+
+    def test_match_vertebrates_species(self, name = 'Pica hudsonia'):
+        result = cdpnq.match_taxa_exact(name)
+        self.assertEqual(result[0]['name'], name)
+        self.assertEqual(result[0]['rank'], 'species')


### PR DESCRIPTION
**Introduced features**

- Split workflow between taxaRef and Vernacular
- No full string matching in Vernacular; queries directly on tables (no use of fts5 tables)

**Changes to the code**

- Introduction of distinct functions `match_taxa` and `match_taxa_exact` for taxa_ref and Vernacular
- Introduction of distinct functions in cdpnq and byoquel modules for full string matching and exact matching
    - Added `cdpnq.match_taxa_exact`, `cdpnq.match_taxa_odonates_exact`, and `cdpnq.match_taxa_vertebrates_exact` functions
    - Added `bryoquel.match_taxa_exact` function