### PR TITLE
Added form to gbif accepted ranks

### DIFF
--- a/bdqc_taxa/taxa_ref.py
+++ b/bdqc_taxa/taxa_ref.py
@@ -15,7 +15,7 @@ CDPNQ_SOURCE_KEY = 1002 # Not in global names so start at 1000
 
 GBIF_SOURCE_NAME = 'GBIF Backbone Taxonomy'
 GBIF_RANKS = ['kingdom', 'phylum', 'class', 'order', 'family',
-                'genus', 'species', 'subspecies', 'variety']
+                'genus', 'species', 'subspecies', 'variety', 'form']
 
 DATA_SOURCES = [1, 3, 147] # COL, ITIS, VASCAN
 


### PR DESCRIPTION
J'ai ajouté le rank `form` dans les ranks acceptés pour GBIF.
Il y a ~ 130 taxa_obs qui ne sont pas injectés dans taxa_ref parce que `form` n'est pas dans `GBIF_RANKS`.