### PR TITLE
Patch custom sources

### DIFF
--- a/bdqc_taxa/__about__.py
+++ b/bdqc_taxa/__about__.py
@@ -16,7 +16,7 @@ __uri__ = "https://github.com/ReseauBiodiversiteQuebec/bdqc-taxa"
 _version = OrderedDict(
     major = 0,
     minor = 16,
-    patch = 3
+    patch = 4
 )
 __version__ = ".".join([str(v) for v in _version.values()])
 

--- a/bdqc_taxa/cdpnq.py
+++ b/bdqc_taxa/cdpnq.py
@@ -73,8 +73,7 @@ def match_taxa_odonates(name) -> dict:
             'synonym': result[3],
             'author': result[4],
             'canonical_full': result[5],
-            'vernacular_fr': result[6],
-            'vernacular_fr2': result[7]
+            'vernacular_fr': result[6]
         }
     else:
         return None


### PR DESCRIPTION
Remove the field `vernacular_fr2` as there is no second french vernacular name anymore with the new cdpnq_odonate file format.