### PR TITLE
Modify test with odonates with authorship

### DIFF
--- a/tests/test_taxa_ref.py
+++ b/tests/test_taxa_ref.py
@@ -99,7 +99,7 @@ class TestTaxaRef(unittest.TestCase):
         ]
         self.assertFalse(bad_refs)
     
-    def test_from_cdpnq(self, name='Libellula luctuosa'):
+    def test_from_cdpnq(self, name='Lestes vigilax'):
         refs = taxa_ref.TaxaRef.from_cdpnq(name)
         self.assertTrue(len(refs) > 1)
         [self.assertTrue(v) for ref in refs for k, v in vars(ref).items()


### PR DESCRIPTION
J'ai changé le nom utilisé pour le test puisque dans la nouvelle liste obtenue pour les noms d'odonates, le taxon `Libellula luctuosa` n'avait plus d'`authorship` alors le test échouait.
J'ai donc mis un nom qui avait un `authorship`.