### PR TITLE
Fix the fail

### DIFF
--- a/bdqc_taxa/__about__.py
+++ b/bdqc_taxa/__about__.py
@@ -16,7 +16,7 @@ __uri__ = "https://github.com/ReseauBiodiversiteQuebec/bdqc-taxa"
 _version = OrderedDict(
     major = 0,
     minor = 16,
-    patch = 9
+    patch = 10
 )
 __version__ = ".".join([str(v) for v in _version.values()])
 

--- a/bdqc_taxa/global_names.py
+++ b/bdqc_taxa/global_names.py
@@ -120,10 +120,11 @@ def verify(name: str, authorship: str = None, data_sources: list = DATA_SOURCES,
             pass
         
         if authorship:
-            names[i]['results'] = _solve_authorship_conflicts(name['results'])
-        else:
-            pass
-    
+            try:
+                names[i]['results'] = _solve_authorship_conflicts(name['results'])
+            except KeyError:
+                pass
+
     gn_out['names'] = names
 
     return gn_out

--- a/tests/test_global_names.py
+++ b/tests/test_global_names.py
@@ -35,3 +35,8 @@ class TestGlobalNames(TestCase):
         # This means that there are only one entry per data sources which is what we expect
         self.assertTrue(len(set(data_source_ids)) == len(result))
         
+    def test_gn_no_match_pass_authorship_step(self, name='Antigone canadensis', authorship='(Linnaeus, 1758)'):
+        results = global_names.verify(name, authorship)
+        self.assertTrue(len(results) > 0)
+        self.assertTrue(results['names'][0]['matchType'] == 'NoMatch')
+        


### PR DESCRIPTION
Le changement de parse les output de gnverifier en fonction du authorship/best_match n'était pas encapsulé dans un try/catch/pass et si le résultat de gnverifier était vide, ça renvoyait une erreur qui faisait planter le pipeline pour le taxon x.