### PR TITLE
Fix gbif classification ids

### DIFF
--- a/bdqc_taxa/__about__.py
+++ b/bdqc_taxa/__about__.py
@@ -16,7 +16,7 @@ __uri__ = "https://github.com/ReseauBiodiversiteQuebec/bdqc-taxa"
 _version = OrderedDict(
     major = 0,
     minor = 16,
-    patch = 10
+    patch = 11
 )
 __version__ = ".".join([str(v) for v in _version.values()])
 

--- a/bdqc_taxa/taxa_ref.py
+++ b/bdqc_taxa/taxa_ref.py
@@ -219,7 +219,8 @@ class TaxaRef:
 
         # Create rows for valid taxon
         classification_srids = [
-            result[f'{k}Key'] for k in GBIF_RANKS if k in result.keys()]
+            result[f'{k}Key'] for k in GBIF_RANKS if k in result.keys()] + ([result['key']] if 'key' in result else [])
+        classification_srids = list(set(classification_srids))
         
         try:
             rank_order = GBIF_RANKS.index(result['rank'].lower())

--- a/tests/test_taxa_ref.py
+++ b/tests/test_taxa_ref.py
@@ -336,6 +336,13 @@ class TestTaxaRef(unittest.TestCase):
         matches =  [ref for ref in results if (ref.match_type == 'partialexact' and ref.is_parent == False)]
         self.assertTrue(len(matches) == 0)
 
+    def test_gbif_catharus_swainsoni(self, name='Catharus swainsoni', authorship='(Tschudi, 1845)', parent_taxa='Chordata'):
+        results = taxa_ref.TaxaRef.from_all_sources(name, authorship, parent_taxa)
+        self.assertTrue(
+            any(res.scientific_name == 'Catharus ustulatus swainsoni' and
+                res.source_name == 'GBIF Backbone Taxonomy' for res in results)
+        )
+        
 class TestComplex(unittest.TestCase):
     def test_complex_is_true(self,
                              name='Lasiurus cinereus|Lasionycteris noctivagans'):


### PR DESCRIPTION
Dans GBIF match, si le taxon était une sous-espèce, le srid_key de la sous-espèce n'était pas envoyé dans le `classification_srids` et était donc enlevé par prune_parent_taxa.
Conséquemment, dans taxa_ref il n'y avait pas d'entrée is_parent = false pour le taxon, et donc rien dans api.taxa.