### PR TITLE
Fixed caribou test for rank species

### DIFF
--- a/tests/test_cdpnq.py
+++ b/tests/test_cdpnq.py
@@ -57,7 +57,7 @@ class TestCdpnqVertebrates(unittest.TestCase):
     def test_rangifer_tarandus(self, name = 'Rangifer tarandus'):
         result = cdpnq.match_taxa_vertebrates(name)
         self.assertTrue(result['valid_name'] == 'Rangifer tarandus caribou')
-        self.assertTrue(result['rank'] == 'subspecies')
+        self.assertTrue(result['rank'] == 'species')
         self.assertTrue(result['synonym'] == 1)
         self.assertTrue(result['vernacular_fr'] == 'Caribou des bois')
         self.assertTrue(result['vernacular_en'] == 'Woodland Caribou')


### PR DESCRIPTION
Fix the test.
The test was modified instead of making a new one, because this is the actual behavior that we want.