### PR TITLE
Fixed doublematching with custom sources regarding fuzzy names

### DIFF
--- a/bdqc_taxa/__about__.py
+++ b/bdqc_taxa/__about__.py
@@ -16,7 +16,7 @@ __uri__ = "https://github.com/ReseauBiodiversiteQuebec/bdqc-taxa"
 _version = OrderedDict(
     major = 0,
     minor = 16,
-    patch = 11
+    patch = 12
 )
 __version__ = ".".join([str(v) for v in _version.values()])
 

--- a/bdqc_taxa/taxa_ref.py
+++ b/bdqc_taxa/taxa_ref.py
@@ -342,10 +342,13 @@ class TaxaRef:
         out.extend(cls.from_cdpnq(name)) # exact match only
         
         # Fuzzy match for custom sources
-        fuzzy_names = list({(ref.scientific_name, ref.match_type) for ref in out
-                       if not ref.is_parent and ref.match_type != 'exact'})
+        if not any(ref.source_name in ('CDPNQ', 'Bryoquel') for ref in out):
+            fuzzy_names = list({(ref.scientific_name, ref.match_type) for ref in out
+                               if not ref.is_parent and ref.match_type != 'exact'})
+        else : 
+            fuzzy_names = []
         
-        if len(fuzzy_names) >= 1:
+        if fuzzy_names:
             for fuzzy_name, match_type in fuzzy_names:
                 out.extend(cls.from_custom_sources_fuzzy_matched(fuzzy_name, match_type))
             

--- a/tests/test_taxa_ref.py
+++ b/tests/test_taxa_ref.py
@@ -343,6 +343,13 @@ class TestTaxaRef(unittest.TestCase):
                 res.source_name == 'GBIF Backbone Taxonomy' for res in results)
         )
         
+    def test_cod_cdpnq_no_doublematch(self, name='Gadus ogac', authorship='Tilesius, 1810', parent_taxa=''):
+        results = taxa_ref.TaxaRef.from_all_sources(name, authorship, parent_taxa)
+        self.assertTrue(
+            not any(res.scientific_name == 'Gadus macrocephalus' and
+                    res.source_name == 'CDPNQ' for res in results)
+        )
+
 class TestComplex(unittest.TestCase):
     def test_complex_is_true(self,
                              name='Lasiurus cinereus|Lasionycteris noctivagans'):


### PR DESCRIPTION
J'ai aussi ajouté un test associé à au nouveau comportement.

En bref, si on a déjà un match dans `out` avec une de nos custom sources scientifiques (CDPNQ et Bryoquel), on ne refait pas de match avec les fuzzy names dans ces custom sources. Ça provoquait des cas où pour un taxa_obs, on avait 2 noms scientifiques acceptés pour des custom sources.