### PR TITLE
Implement nature serve api wrapper #65

### DIFF
--- a/bdqc_taxa/src/__init__.py
+++ b/bdqc_taxa/src/__init__.py
@@ -19,6 +19,7 @@ from . import vernacular
 from . import taxa_ref
 from . import eliso
 from . import cdpnq
+from . import natureserve
 
 __all__ = [
     "__title__",
@@ -35,4 +36,5 @@ __all__ = [
     "taxa_ref",
     "eliso",
     "cdpnq",
+    "natureserve",
 ]

--- a/bdqc_taxa/src/natureserve.py
+++ b/bdqc_taxa/src/natureserve.py
@@ -4,6 +4,22 @@ from urllib.parse import urlencode
 
 HOST = "https://explorer.natureserve.org/api"
 
+MATCH_AGAINST = [
+    "scientificName",
+    "allScientificNames",
+    "primaryCommonName",
+    "allCommonNames",
+    "allNames",
+    "code"
+]
+
+SIMILARITY_OPERATORS = [
+    "similarTo",
+    "contains",
+    "startsWith",
+    "equals"
+]
+
 
 def _get_url_data(url, method="GET", params=None, body=None):
     """
@@ -51,7 +67,9 @@ def get_taxon(global_id):
     return _get_url_data(url, method="GET")
 
 
-def search_species(search_token, page=None, records_per_page=None):
+def search_species(search_token,
+                   operator ="similarTo", match_against="allScientificNames",
+                   page=None, records_per_page=None):
     """
     SearchSpecies via POST with criteriaType, textCriteria, and pagingOptions.
 
@@ -63,6 +81,13 @@ def search_species(search_token, page=None, records_per_page=None):
     search_token : str
         Token to match against all scientific names (primary and synonyms)
         using a “similarTo” operator.
+    operator : str, optional
+        Similarity operator to use for the search. Default is "similarTo".
+        Other options include "contains", "startsWith", and "equals".
+    match_against : str, optional
+        Field to match against. Default is "allScientificNames".
+        Other options include "scientificName", "primaryCommonName",
+        "allCommonNames", "allNames", and "code".
     page : int, optional
         Page number for pagination.
     records_per_page : int, optional
@@ -73,6 +98,12 @@ def search_species(search_token, page=None, records_per_page=None):
     dict
         JSON response containing search metadata and results under 'data' key.
     """
+    if operator not in SIMILARITY_OPERATORS:
+        raise ValueError(f"Invalid operator: {operator}. Must be one of {SIMILARITY_OPERATORS}.")
+    
+    if match_against not in MATCH_AGAINST:
+        raise ValueError(f"Invalid match_against: {match_against}. Must be one of {MATCH_AGAINST}.")
+
     url = f"{HOST}/data/speciesSearch"
     body = {
         "criteriaType": "species",
@@ -80,8 +111,8 @@ def search_species(search_token, page=None, records_per_page=None):
             {
                 "paramType": "textSearch",
                 "searchToken": search_token,
-                "matchAgainst": "allScientificNames",
-                "operator": "similarTo"
+                "operator": operator,
+                "matchAgainst": match_against
             }
         ],
         "pagingOptions": {

--- a/bdqc_taxa/src/natureserve.py
+++ b/bdqc_taxa/src/natureserve.py
@@ -2,7 +2,33 @@ import json
 from urllib.request import Request, urlopen, URLError, HTTPError
 from urllib.parse import urlencode
 
+from datetime import datetime
+
 HOST = "https://explorer.natureserve.org/api"
+
+CURRENT_DATE = datetime.now()
+
+# Metadata is generated from Terms of Use and Citations to reflect DublinCore metadata structure
+# https://explorer.natureserve.org/AboutTheData/UseGuidelinesCitations
+METADATA = {
+    "title": "NatureServe Explorer API",
+    "description": "Provides access to NatureServe's biodiversity data, including taxon record retrieval and species search.",
+    "creator": "NatureServe",
+    "publisher": "NatureServe",
+    "date": CURRENT_DATE.strftime("%Y-%m-%d"),
+    "termsOfUse": "https://explorer.natureserve.org/AboutTheData/UseGuidelinesCitations",
+    "logo": "https://www.natureserve.org/sites/default/files/2022-07/network_logo_250.jpg",
+    "rights": "Use governed by NatureServe’s Use Guidelines and Citations.",
+    "citation": f"NatureServe. {CURRENT_DATE.year}. NatureServe Network Biodiversity Location Data accessed through NatureServe Explorer. NatureServe, Arlington, Virginia. Available https://explorer.natureserve.org/. (Accessed: {CURRENT_DATE.strftime('%B %d, %Y')}).",
+    "licenseURL": "https://explorer.natureserve.org/AboutTheData/UseGuidelinesCitations",
+    "creator": "NatureServe",
+    "creatorURL": "https://explorer.natureserve.org/",
+    "contact": "DataSupport@natureserve.org",
+    "resourceType": "api",
+    "resourceURL": "https://explorer.natureserve.org/api",
+    "resourceName": "NatureServe Explorer API",
+    "resourceDescription": "NatureServe Explorer API provides access to NatureServe's biodiversity data.",
+}
 
 MATCH_AGAINST = [
     "scientificName",

--- a/bdqc_taxa/src/natureserve.py
+++ b/bdqc_taxa/src/natureserve.py
@@ -183,5 +183,5 @@ def search_species(species_search_token=None,
 
     result = _get_url_data(url, method="POST", body=body)
     if not isinstance(result, dict) or 'results' not in result:
-        return []
-    return result["results"]
+        return None
+    return result

--- a/bdqc_taxa/src/natureserve.py
+++ b/bdqc_taxa/src/natureserve.py
@@ -1,0 +1,95 @@
+import json
+from urllib.request import Request, urlopen, URLError, HTTPError
+from urllib.parse import urlencode
+
+HOST = "https://explorer.natureserve.org/api"
+
+
+def _get_url_data(url, method="GET", params=None, body=None):
+    """
+    Internal helper using urllib to GET or POST JSON.
+    """
+    # append query params for GET
+    if params:
+        url = f"{url}?{urlencode(params)}"
+    data = None
+    headers = {"Content-Type": "application/json"}
+    if method.upper() == "POST" and body is not None:
+        data = json.dumps(body).encode("utf-8")
+    req = Request(url, data=data, headers=headers)
+    try:
+        resp = urlopen(req, timeout=10)
+    except HTTPError as e:
+        return {"error": str(e)}
+    except URLError as e:
+        return {"error": str(e)}
+    else:
+        try:
+            return json.loads(resp.read().decode("utf-8"))
+        except Exception:
+            return {}
+
+
+def get_taxon(global_id):
+    """
+    Fetch a taxon record by its global ID from NatureServe.
+
+    Api reference:
+    https://explorer.natureserve.org/api-docs/#_get_taxon
+
+    Parameters
+    ----------
+    global_id : str
+        The NatureServe taxon global identifier (e.g., 'ELEMENT_GLOBAL.2.160636').
+
+    Returns
+    -------
+    dict
+        JSON response as a dictionary.
+    """
+    url = f"{HOST}/data/taxon/{global_id}"
+    return _get_url_data(url, method="GET")
+
+
+def search_species(search_token, page=None, records_per_page=None):
+    """
+    SearchSpecies via POST with criteriaType, textCriteria, and pagingOptions.
+
+    Api reference:
+    https://explorer.natureserve.org/api-docs/#_species_search
+
+    Parameters
+    ----------
+    search_token : str
+        Token to match against all scientific names (primary and synonyms)
+        using a “similarTo” operator.
+    page : int, optional
+        Page number for pagination.
+    records_per_page : int, optional
+        Number of records per page for pagination.
+
+    Returns
+    -------
+    dict
+        JSON response containing search metadata and results under 'data' key.
+    """
+    url = f"{HOST}/data/speciesSearch"
+    body = {
+        "criteriaType": "species",
+        "textCriteria": [
+            {
+                "paramType": "textSearch",
+                "searchToken": search_token,
+                "matchAgainst": "allScientificNames",
+                "operator": "similarTo"
+            }
+        ],
+        "pagingOptions": {
+            "page": page,
+            "recordsPerPage": records_per_page
+        }
+    }
+    result = _get_url_data(url, method="POST", body=body)
+    if not isinstance(result, dict) or 'results' not in result:
+        return []
+    return result["results"]

--- a/bdqc_taxa/tests/test_natureserve.py
+++ b/bdqc_taxa/tests/test_natureserve.py
@@ -4,19 +4,19 @@ from bdqc_taxa.natureserve import get_taxon, search_species
 
 class TestNatureServe(TestCase):
     def test_get_taxon(self, global_id='ELEMENT_GLOBAL.2.160636'):
-        result = get_taxon(global_id)
+        get_result = get_taxon(global_id)
         # Should return a dictionary without an 'error' key
-        self.assertIsInstance(result, dict)
-        self.assertNotIn('error', result)
+        self.assertIsInstance(get_result, dict)
+        self.assertNotIn('error', get_result)
         # Should contain the requested global ID
-        self.assertTrue(result.get('uniqueId') == global_id)
+        self.assertTrue(get_result.get('uniqueId') == global_id)
 
     def test_search_no_match(self, name='Dominique Gravel'):
-        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
+        search_result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
         # Should return a dictionary with 'data' key as a list
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(search_result["results"], list)
         # No matches expected for misspelled name
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(search_result["results"]), 0)
 
     def test_search_match_similar_to(self, name='Matteuccia struthiopteris'):
         # Notes on behavior:
@@ -27,79 +27,79 @@ class TestNatureServe(TestCase):
         # 4. The search returns also infra-specific names
 
         # Test a correct species name returns at least one match
-        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
-        self.assertIsInstance(result, list)
-        self.assertGreaterEqual(len(result), 1)
-        # First result should contain 'scientificName'
-        self.assertIn('scientificName', result[0])
+        search_result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
+        self.assertIsInstance(search_result["results"], list)
+        self.assertGreaterEqual(len(search_result["results"]), 1)
+        # First search_result["results"] should contain 'scientificName'
+        self.assertIn('scientificName', search_result["results"][0])
         # record type of all results should be 'species'
-        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
 
     def test_search_match_exact(self, name='Matteuccia struthiopteris'):
         # Notes on behavior:
         # 1. Returns only the accepted name records but not infra-specific names
         
         # Test a correct species name returns at least one match
-        result = search_species(species_search_token = name, text_search_operator='equals', text_match_against='allScientificNames')
-        self.assertIsInstance(result, list)
-        self.assertEqual(len(result), 1)
-        # First result should contain 'scientificName'
-        self.assertIn('scientificName', result[0])
+        search_result = search_species(species_search_token = name, text_search_operator='equals', text_match_against='allScientificNames')
+        self.assertIsInstance(search_result["results"], list)
+        self.assertEqual(len(search_result["results"]), 1)
+        # First search_result["results"] should contain 'scientificName'
+        self.assertIn('scientificName', search_result["results"][0])
         # record type of all results should be 'species'
-        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
 
-        # Assert record of scientificName Matteuccia struthiopteris in the result
-        self.assertTrue(any(record.get('scientificName') == name for record in result))
+        # Assert record of scientificName Matteuccia struthiopteris in the search_result["results"]
+        self.assertTrue(any(record.get('scientificName') == name for record in search_result["results"]))
 
     def test_search_match_exact_case_insensitive(self, name='MATTEUCCIA STRUTHIOPTERIS'):
         # Notes on behavior:
         # 1. The search is case-sensitive so returns no match.
 
         # Test a correct species name returns at least one match
-        result = search_species(species_search_token = name, text_search_operator='equals', text_match_against='allScientificNames')
-        self.assertIsInstance(result, list)
-        self.assertGreaterEqual(len(result), 1)
+        search_result = search_species(species_search_token = name, text_search_operator='equals', text_match_against='allScientificNames')
+        self.assertIsInstance(search_result["results"], list)
+        self.assertGreaterEqual(len(search_result["results"]), 1)
 
 
     def test_search_match_similar_to_fuzzy(self, name='Matteucia strutiopterys'):
         # Notes on behaviour on fuzzy search: works but not return any attributes indicating fuzzy match
 
         # Test a partial species name returns at least one match
-        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
-        self.assertIsInstance(result, list)
-        self.assertGreaterEqual(len(result), 1)
-        # First result should contain 'scientificName'
-        self.assertIn('scientificName', result[0])
+        search_result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
+        self.assertIsInstance(search_result["results"], list)
+        self.assertGreaterEqual(len(search_result["results"]), 1)
+        # First search_result["results"] should contain 'scientificName'
+        self.assertIn('scientificName', search_result["results"][0])
         # record type of all results should be 'species'
-        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
 
-        # Assert record of scientificName Matteuccia struthiopteris in the result
-        self.assertTrue(any(record.get('scientificName') == 'Matteuccia struthiopteris' for record in result))
+        # Assert record of scientificName Matteuccia struthiopteris in the search_result["results"]
+        self.assertTrue(any(record.get('scientificName') == 'Matteuccia struthiopteris' for record in search_result["results"]))
 
     def test_search_match_synonym(self, name='Picoides villosus', accepted_name='Dryobates villosus'):
         # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
 
         # Test a synonym species name returns at least one match
-        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
-        self.assertIsInstance(result, list)
-        self.assertGreaterEqual(len(result), 1)
-        # First result should contain 'scientificName'
-        self.assertIn('scientificName', result[0])
+        search_result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
+        self.assertIsInstance(search_result["results"], list)
+        self.assertGreaterEqual(len(search_result["results"]), 1)
+        # First search_result["results"] should contain 'scientificName'
+        self.assertIn('scientificName', search_result["results"][0])
         # record type of all results should be 'species'
-        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
 
-        # Assert record of scientificName Dryobates villosus in the result
-        self.assertTrue(any(record.get('scientificName') == accepted_name for record in result))
+        # Assert record of scientificName Dryobates villosus in the search_result["results"]
+        self.assertTrue(any(record.get('scientificName') == accepted_name for record in search_result["results"]))
 
     def test_search_subnation_checklist(self, subnation='QC', nation='CA'):
         # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
 
         # Test a synonym species name returns at least one match
-        result = search_species(nation=nation, subnation=subnation)
-        self.assertIsInstance(result, list)
+        search_result = search_species(nation=nation, subnation=subnation)
+        self.assertIsInstance(search_result["results"], list)
 
-        self.assertGreaterEqual(len(result), 1)
-        # First result should contain 'scientificName'
-        self.assertIn('scientificName', result[0])
+        self.assertGreaterEqual(len(search_result["results"]), 1)
+        # First search_result["results"] should contain 'scientificName'
+        self.assertIn('scientificName', search_result["results"][0])
         # record type of all results should be 'species'
-        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))

--- a/bdqc_taxa/tests/test_natureserve.py
+++ b/bdqc_taxa/tests/test_natureserve.py
@@ -90,11 +90,11 @@ class TestNatureServe(TestCase):
         # Assert record of scientificName Dryobates villosus in the search_result["results"]
         self.assertTrue(any(record.get('scientificName') == accepted_name for record in search_result["results"]))
 
-    def test_search_subnation_checklist(self, subnation='QC', nation='CA'):
+    def test_search_subnation_checklist(self, location_subnation='QC', location_nation='CA'):
         # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
 
         # Test a synonym species name returns at least one match
-        search_result = search_species(nation=nation, subnation=subnation)
+        search_result = search_species(location_nation=location_nation, location_subnation=location_subnation)
         self.assertIsInstance(search_result["results"], list)
 
         self.assertGreaterEqual(len(search_result["results"]), 1)
@@ -103,15 +103,29 @@ class TestNatureServe(TestCase):
         # record type of all results should be 'species'
         self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
 
-    # Test is really slow, so we limit the number of records to 1000
-    # and the number of records per page to 100 (max available by api)
-    def test_search_all_subnation_checklist(self, records_per_page=100, subnation='QC', nation='CA'):
+    def test_search_subnation_exotic_checklist(self, location_subnation='QC', location_nation='CA', location_origin='onlyExotics'):
+        # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
+
+        # Test a synonym species name returns at least one match
+        search_result = search_species(location_nation=location_nation, location_subnation=location_subnation, location_origin=location_origin)
+        self.assertIsInstance(search_result["results"], list)
+
+        self.assertGreaterEqual(len(search_result["results"]), 1)
+        # First search_result["results"] should contain 'scientificName'
+        self.assertIn('scientificName', search_result["results"][0])
+        # record type of all results should be 'species'
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
+
+        # Test is really slow, so we limit the number of records to 1000
+        # and the number of records per page to 100 (max available by api)
+
+    def test_search_all_subnation_checklist(self, records_per_page=100, location_subnation='QC', location_nation='CA'):
         # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
 
         # Test a synonym species name returns at least one match
         search_results = search_all_species(records_per_page=records_per_page,
                                             max_records=1000,
-                                            nation=nation, subnation=subnation)
+                                            location_nation=location_nation, location_subnation=location_subnation)
         self.assertIsInstance(search_results, list)
 
         self.assertGreaterEqual(len(search_results), 1)

--- a/bdqc_taxa/tests/test_natureserve.py
+++ b/bdqc_taxa/tests/test_natureserve.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+from bdqc_taxa.natureserve import get_taxon, search_species
+
+
+class TestNatureServe(TestCase):
+    def test_get_taxon(self, global_id='ELEMENT_GLOBAL.2.160636'):
+        result = get_taxon(global_id)
+        # Should return a dictionary without an 'error' key
+        self.assertIsInstance(result, dict)
+        self.assertNotIn('error', result)
+        # Should contain the requested global ID
+        self.assertTrue(result.get('uniqueId') == global_id)
+
+    def test_search_no_match(self, name='Dominique Gravel'):
+        result = search_species(name)
+        # Should return a dictionary with 'data' key as a list
+        self.assertIsInstance(result, list)
+        # No matches expected for misspelled name
+        self.assertEqual(len(result), 0)
+
+    def test_search_match(self, name='Matteuccia struthiopteris'):
+        # Test a correct species name returns at least one match
+        result = search_species(name)
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+        # First result should contain 'scientificName'
+        self.assertIn('scientificName', result[0])
+        # record type of all results should be 'species'
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+
+    # Additional tests can be added here

--- a/bdqc_taxa/tests/test_natureserve.py
+++ b/bdqc_taxa/tests/test_natureserve.py
@@ -12,15 +12,22 @@ class TestNatureServe(TestCase):
         self.assertTrue(result.get('uniqueId') == global_id)
 
     def test_search_no_match(self, name='Dominique Gravel'):
-        result = search_species(name)
+        result = search_species(name, operator='similarTo', match_against='allScientificNames')
         # Should return a dictionary with 'data' key as a list
         self.assertIsInstance(result, list)
         # No matches expected for misspelled name
         self.assertEqual(len(result), 0)
 
-    def test_search_match(self, name='Matteuccia struthiopteris'):
+    def test_search_match_similar_to(self, name='Matteuccia struthiopteris'):
+        # Notes on behavior:
+        # 1. The search is case-insensitive.
+        # 2. The search is not exact, so it may return more than one match.
+        # 3. The search may return synonyms, so the result may not contain
+        #    the exact scientific name.
+        # 4. The search returns also infra-specific names
+
         # Test a correct species name returns at least one match
-        result = search_species(name)
+        result = search_species(name, operator='similarTo', match_against='allScientificNames')
         self.assertIsInstance(result, list)
         self.assertGreaterEqual(len(result), 1)
         # First result should contain 'scientificName'
@@ -28,4 +35,58 @@ class TestNatureServe(TestCase):
         # record type of all results should be 'species'
         self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
 
-    # Additional tests can be added here
+    def test_search_match_exact(self, name='Matteuccia struthiopteris'):
+        # Notes on behavior:
+        # 1. Returns only the accepted name records but not infra-specific names
+        
+        # Test a correct species name returns at least one match
+        result = search_species(name, operator='equals', match_against='allScientificNames')
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        # First result should contain 'scientificName'
+        self.assertIn('scientificName', result[0])
+        # record type of all results should be 'species'
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+
+        # Assert record of scientificName Matteuccia struthiopteris in the result
+        self.assertTrue(any(record.get('scientificName') == name for record in result))
+
+    def test_search_match_exact_case_insensitive(self, name='MATTEUCCIA STRUTHIOPTERIS'):
+        # Notes on behavior:
+        # 1. The search is case-sensitive so returns no match.
+
+        # Test a correct species name returns at least one match
+        result = search_species(name, operator='equals', match_against='allScientificNames')
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+
+
+    def test_search_match_similar_to_fuzzy(self, name='Matteucia strutiopterys'):
+        # Notes on behaviour on fuzzy search: works but not return any attributes indicating fuzzy match
+
+        # Test a partial species name returns at least one match
+        result = search_species(name, operator='similarTo', match_against='allScientificNames')
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+        # First result should contain 'scientificName'
+        self.assertIn('scientificName', result[0])
+        # record type of all results should be 'species'
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+
+        # Assert record of scientificName Matteuccia struthiopteris in the result
+        self.assertTrue(any(record.get('scientificName') == 'Matteuccia struthiopteris' for record in result))
+
+    def test_search_match_synonym(self, name='Picoides villosus', accepted_name='Dryobates villosus'):
+        # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
+
+        # Test a synonym species name returns at least one match
+        result = search_species(name, operator='similarTo', match_against='allScientificNames')
+        self.assertIsInstance(result, list)
+        self.assertGreaterEqual(len(result), 1)
+        # First result should contain 'scientificName'
+        self.assertIn('scientificName', result[0])
+        # record type of all results should be 'species'
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))
+
+        # Assert record of scientificName Dryobates villosus in the result
+        self.assertTrue(any(record.get('scientificName') == accepted_name for record in result))

--- a/bdqc_taxa/tests/test_natureserve.py
+++ b/bdqc_taxa/tests/test_natureserve.py
@@ -103,11 +103,15 @@ class TestNatureServe(TestCase):
         # record type of all results should be 'species'
         self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
 
+    # Test is really slow, so we limit the number of records to 1000
+    # and the number of records per page to 100 (max available by api)
     def test_search_all_subnation_checklist(self, records_per_page=100, subnation='QC', nation='CA'):
         # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
 
         # Test a synonym species name returns at least one match
-        search_results = search_all_species(records_per_page=records_per_page, nation=nation, subnation=subnation)
+        search_results = search_all_species(records_per_page=records_per_page,
+                                            max_records=1000,
+                                            nation=nation, subnation=subnation)
         self.assertIsInstance(search_results, list)
 
         self.assertGreaterEqual(len(search_results), 1)

--- a/bdqc_taxa/tests/test_natureserve.py
+++ b/bdqc_taxa/tests/test_natureserve.py
@@ -12,7 +12,7 @@ class TestNatureServe(TestCase):
         self.assertTrue(result.get('uniqueId') == global_id)
 
     def test_search_no_match(self, name='Dominique Gravel'):
-        result = search_species(name, operator='similarTo', match_against='allScientificNames')
+        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
         # Should return a dictionary with 'data' key as a list
         self.assertIsInstance(result, list)
         # No matches expected for misspelled name
@@ -27,7 +27,7 @@ class TestNatureServe(TestCase):
         # 4. The search returns also infra-specific names
 
         # Test a correct species name returns at least one match
-        result = search_species(name, operator='similarTo', match_against='allScientificNames')
+        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
         self.assertIsInstance(result, list)
         self.assertGreaterEqual(len(result), 1)
         # First result should contain 'scientificName'
@@ -40,7 +40,7 @@ class TestNatureServe(TestCase):
         # 1. Returns only the accepted name records but not infra-specific names
         
         # Test a correct species name returns at least one match
-        result = search_species(name, operator='equals', match_against='allScientificNames')
+        result = search_species(species_search_token = name, text_search_operator='equals', text_match_against='allScientificNames')
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 1)
         # First result should contain 'scientificName'
@@ -56,7 +56,7 @@ class TestNatureServe(TestCase):
         # 1. The search is case-sensitive so returns no match.
 
         # Test a correct species name returns at least one match
-        result = search_species(name, operator='equals', match_against='allScientificNames')
+        result = search_species(species_search_token = name, text_search_operator='equals', text_match_against='allScientificNames')
         self.assertIsInstance(result, list)
         self.assertGreaterEqual(len(result), 1)
 
@@ -65,7 +65,7 @@ class TestNatureServe(TestCase):
         # Notes on behaviour on fuzzy search: works but not return any attributes indicating fuzzy match
 
         # Test a partial species name returns at least one match
-        result = search_species(name, operator='similarTo', match_against='allScientificNames')
+        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
         self.assertIsInstance(result, list)
         self.assertGreaterEqual(len(result), 1)
         # First result should contain 'scientificName'
@@ -80,7 +80,7 @@ class TestNatureServe(TestCase):
         # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
 
         # Test a synonym species name returns at least one match
-        result = search_species(name, operator='similarTo', match_against='allScientificNames')
+        result = search_species(species_search_token = name, text_search_operator='similarTo', text_match_against='allScientificNames')
         self.assertIsInstance(result, list)
         self.assertGreaterEqual(len(result), 1)
         # First result should contain 'scientificName'
@@ -90,3 +90,16 @@ class TestNatureServe(TestCase):
 
         # Assert record of scientificName Dryobates villosus in the result
         self.assertTrue(any(record.get('scientificName') == accepted_name for record in result))
+
+    def test_search_subnation_checklist(self, subnation='QC', nation='CA'):
+        # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
+
+        # Test a synonym species name returns at least one match
+        result = search_species(nation=nation, subnation=subnation)
+        self.assertIsInstance(result, list)
+
+        self.assertGreaterEqual(len(result), 1)
+        # First result should contain 'scientificName'
+        self.assertIn('scientificName', result[0])
+        # record type of all results should be 'species'
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in result))

--- a/bdqc_taxa/tests/test_natureserve.py
+++ b/bdqc_taxa/tests/test_natureserve.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
-from bdqc_taxa.natureserve import get_taxon, search_species
-
+from bdqc_taxa.natureserve import get_taxon, search_species, search_all_species
 
 class TestNatureServe(TestCase):
     def test_get_taxon(self, global_id='ELEMENT_GLOBAL.2.160636'):
@@ -103,3 +102,16 @@ class TestNatureServe(TestCase):
         self.assertIn('scientificName', search_result["results"][0])
         # record type of all results should be 'species'
         self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_result["results"]))
+
+    def test_search_all_subnation_checklist(self, records_per_page=100, subnation='QC', nation='CA'):
+        # Notes on behaviour on synonym search: Returns only the accepted name records and infra-specific names
+
+        # Test a synonym species name returns at least one match
+        search_results = search_all_species(records_per_page=records_per_page, nation=nation, subnation=subnation)
+        self.assertIsInstance(search_results, list)
+
+        self.assertGreaterEqual(len(search_results), 1)
+        # First search_results should contain 'scientificName'
+        self.assertIn('scientificName', search_results[0])
+        # record type of all results should be 'species'
+        self.assertTrue(all(record.get('recordType') == 'SPECIES' for record in search_results))


### PR DESCRIPTION
Only wrapper function to make some tests in python and enentually implement in Taxa_ref.

Next tasks (out of scope)

Overlap of taxa_names with cdpnq liste faune vertébrés
Implement in taxa_ref from_natureserve method and from all_sources.
Add column for dynamic_properties to store addtl info from api response (status, native, exotic, etc)
Insert checklist into taxa_ref