### PR TITLE
build api.taxa as a join of taxa_view on obs_species

### DIFF
--- a/db/schema/taxa_view.sql
+++ b/db/schema/taxa_view.sql
@@ -54,7 +54,25 @@ BEGIN
     DELETE FROM api.taxa;
 
 	INSERT INTO api.taxa
-	SELECT * FROM rubus.taxa_view;
+	SELECT 
+        coalesce(tv.id_taxa_obs, tobs.id) as id_taxa_obs,
+        coalesce(tv.observed_scientific_name, tobs.scientific_name) as observed_scientific_name,
+        tv.valid_scientific_name,
+        coalesce(tv.rank, tobs.rank) as rank,
+        tv.sensitive,
+        tv.vernacular_en text,
+        tv.vernacular_fr text,
+        tv.group_en text,
+        tv.group_fr text,
+        tv.kingdom text,
+        tv.phylum text,
+        tv.class text,
+        tv."order" text,
+        tv.family text,
+        tv.genus text,
+        tv.species text
+    FROM taxa_obs tobs
+    left join rubus.taxa_view tv on tv.id_taxa_obs=tobs.id;
 END;
 $BODY$;
 
@@ -69,8 +87,8 @@ CREATE TABLE IF NOT EXISTS api.taxa(
 	id_taxa_obs integer NOT NULL,
 	observed_scientific_name text NOT NULL,
 	valid_scientific_name text,
-	rank text NOT NULL,
-	sensitive boolean NOT NULL,
+	rank text,
+	sensitive boolean,
 	vernacular_en text,
 	vernacular_fr text,
 	group_en text,

--- a/db/schema/taxa_view.sql
+++ b/db/schema/taxa_view.sql
@@ -19,7 +19,7 @@ SELECT
     genus.scientific_name as genus,
     species.scientific_name as species
 FROM taxa_obs
-LEFT JOIN rubus.taxa_obs_ref_preferred ref_pref ON taxa_obs.id = ref_pref.id_taxa_obs
+LEFT JOIN rubus.taxa_obs_ref_preferred ref_pref ON taxa_obs.id = ref_pref.id_taxa_obs AND ref_pref.is_match IS TRUE
 LEFT JOIN rubus.taxa_ref_vernacular_preferred vernacular_pref ON ref_pref.id_taxa_ref = vernacular_pref.id_taxa_ref
 LEFT JOIN 
   (SELECT * FROM rubus.taxa_obs_group_lookup WHERE taxa_obs_group_lookup.short_group::text = 'SENSITIVE'::text)
@@ -36,8 +36,7 @@ LEFT JOIN rubus.taxa_obs_ref_preferred class ON class.rank = 'class' AND class.i
 LEFT JOIN rubus.taxa_obs_ref_preferred "order" ON "order".rank = 'order' AND "order".id_taxa_obs = ref_pref.id_taxa_obs
 LEFT JOIN rubus.taxa_obs_ref_preferred family ON family.rank = 'family' AND family.id_taxa_obs = ref_pref.id_taxa_obs
 LEFT JOIN rubus.taxa_obs_ref_preferred genus ON genus.rank = 'genus' AND genus.id_taxa_obs = ref_pref.id_taxa_obs
-LEFT JOIN rubus.taxa_obs_ref_preferred species ON species.rank = 'species' AND species.id_taxa_obs = ref_pref.id_taxa_obs
-WHERE ref_pref.is_match IS TRUE;
+LEFT JOIN rubus.taxa_obs_ref_preferred species ON species.rank = 'species' AND species.id_taxa_obs = ref_pref.id_taxa_obs;
 
 ALTER TABLE rubus.taxa_view
     OWNER TO coleo;
@@ -54,25 +53,7 @@ BEGIN
     DELETE FROM api.taxa;
 
 	INSERT INTO api.taxa
-	SELECT 
-        coalesce(tv.id_taxa_obs, tobs.id) as id_taxa_obs,
-        coalesce(tv.observed_scientific_name, tobs.scientific_name) as observed_scientific_name,
-        tv.valid_scientific_name,
-        coalesce(tv.rank, tobs.rank) as rank,
-        tv.sensitive,
-        tv.vernacular_en text,
-        tv.vernacular_fr text,
-        tv.group_en text,
-        tv.group_fr text,
-        tv.kingdom text,
-        tv.phylum text,
-        tv.class text,
-        tv."order" text,
-        tv.family text,
-        tv.genus text,
-        tv.species text
-    FROM taxa_obs tobs
-    left join rubus.taxa_view tv on tv.id_taxa_obs=tobs.id;
+	SELECT * FROM rubus.taxa_view;
 END;
 $BODY$;
 


### PR DESCRIPTION
Testé et agi tel qu'attendu. Résout certains problèmes:

- Tous les taxa_obs sont représentés dans `api.taxa`
- Rank et sensitive sont affichés seulement lorsque l'information est disponible
- Les champs dont l'information est inconnue affichent `NULL`