### PR TITLE
fixed prob acceptedusagekey

### DIFF
--- a/bdqc_taxa/src/taxa_ref.py
+++ b/bdqc_taxa/src/taxa_ref.py
@@ -225,7 +225,10 @@ class TaxaRef:
                 "is_parent": is_parent
             }
             out.append(cls(**out_kwargs))
-            result = gbif.Species.get(match_species['acceptedUsageKey'])
+            if "acceptedUsageKey" in match_species.keys():
+                result = gbif.Species.get(match_species['acceptedUsageKey'])
+            else:
+                result = gbif.Species.get(result['acceptedKey'])
 
         # Create rows for valid taxon
         classification_srids = [

--- a/bdqc_taxa/tests/test_taxa_ref.py
+++ b/bdqc_taxa/tests/test_taxa_ref.py
@@ -393,6 +393,9 @@ class TestTaxaRef(unittest.TestCase):
                     res.source_name == 'CDPNQ' for res in results)
         )
 
+    def test_matchspecies_no_accepted_usage_key(self, name='Oncophorus wahlenbergii'):
+        results = taxa_ref.TaxaRef.from_all_sources(name)
+        self.assertTrue(len(results) > 0)
 class TestComplex(unittest.TestCase):
     # Test for Myotis complex entries from CDPNQ
     def test_cdpnq_complex_myotis(self, name='Myotis lucifugus|Myotis septentrionalis|Myotis leibii'):


### PR DESCRIPTION
Je dirais que c'est un peu un quick and dirty fix, mais c'est quand même chiant parce que c'est du côté de GBIF que le output de leur API n'est pas constant selon différent scénario (voir bdqc_taxa issue #91).

Tous les tests passent.