### PR TITLE
added install_require psycopg2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,13 @@ setuptools.setup(
         'bdqc_taxa': ['../custom_sources.sqlite', 'custom_sources.sqlite']
     },
     python_requires=">=3.6",
+    install_requires=[
+        "psycopg2"
+    ],
     extras_require={
         'dev': [
             'pandas',
             'numpy'
         ],
-    },
+    }
 )


### PR DESCRIPTION
Added psycopg2 as installed dependency.
L'autre option serait de le mettre dans extras_required pour l'install `dev`, qu'on pourrait utiliser juste en local pour pouvoir rouler les tests genre? (c'est juste pour ça qu'on a besoin de psycopg2...)? 

Ah non, mais vu où psycopg2 est import dans les fichiers du package s'il n'est pas toujours installé ça va renvoyer l'erreur comme quoi le package psycopg2 est manquant... donc je pense en fait qu'il faut qu'il soit dans les install_requires....?

Merci de lire mes pensées au fur et à mesure qu'elles sont pensées.