### PR TITLE
Added fuzzy subsp cdpnq processing + test

### DIFF
--- a/bdqc_taxa/tests/test_taxa_ref.py
+++ b/bdqc_taxa/tests/test_taxa_ref.py
@@ -407,6 +407,13 @@ class TestTaxaRef(unittest.TestCase):
         canis_lupus_results = [res for res in results if res.scientific_name == 'Canis lupus']
         self.assertTrue(len(canis_lupus_results) == 0)
 
+    def test_catharus_swainsoni_cdpnq_subsp_processing(self, name='Catharus swainsoni', authorship='(Tschudi, 1845)', parent_taxa='Chordata'):
+        results = taxa_ref.TaxaRef.from_all_sources(name, authorship)
+        cdpnq_results = [res for res in results if res.source_name == 'CDPNQ']
+        self.assertTrue(len(cdpnq_results) > 1)
+        self.assertTrue(any([res for res in cdpnq_results if res.rank == 'genus' and res.scientific_name == 'Catharus']))
+        self.assertTrue(any([res for res in cdpnq_results if res.rank == 'species' and res.scientific_name == 'Catharus ustulatus']))
+
 class TestComplex(unittest.TestCase):
     # Test for Myotis complex entries from CDPNQ
     def test_cdpnq_complex_myotis(self, name='Myotis lucifugus|Myotis septentrionalis|Myotis leibii'):


### PR DESCRIPTION
J'ai ajouté comme on avait dit le processing du rang espèce pour une sous-espèce qui n'a pas match direct dans le CDPNQ ou Bryoquel, et un test pour `Catharus swainsoni`.
Tous les tests passent.

Deux questionnement:

1. Est-ce qu'on veut changer le match_type pour ces matchs fuzzy qu'on fait manuellement? (Sinon ils gardent le match_type du match duquel ils proviennent, et c'est pas toujours souhaitable si c'était None par exemple). Je suggère `fuzzymanual`.
2. En ce moment le fuzzy `Catharus ustulatus` qui est renvoyé à CDPNQ ressort avec un `is_parent` = `False`, alors qu'il y a bien un match chez GBIF au niveau du `subspecies`. Je ne suis pas certain du comportement qu'on veut ici....